### PR TITLE
adding bam index as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2025-03-10
 ### Added
 - [GRD-833](https://jira.oicr.on.ca/browse/GRD-833), first verion of the wdl along with README and vidarr files
+
+
+## [1.0.1] - 2025-04-01
+### Added
+- Added bam index as input of workflow

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ java -jar cromwell.jar run vardict.wdl --inputs inputs.json
 Parameter|Value|Description
 ---|---|---
 `tumor_bam`|File|tumor_bam file for analysis sample
+`tumor_bai`|File|index for tumor bam file
 `normal_bam`|File|normal_bam file for analysis sample
+`normal_bai`|File|index for normal bam file
 `tumor_sample_name`|String|Sample name for the tumor bam
 `normal_sample_name`|String|Sample name for the normal bam
 `bed_file`|String|BED files for specifying regions of interest

--- a/vardict.wdl
+++ b/vardict.wdl
@@ -11,7 +11,9 @@ struct GenomeResources {
 workflow vardict {
     input {
         File tumor_bam
+        File tumor_bai
         File normal_bam
+        File normal_bai
         String tumor_sample_name
         String normal_sample_name
         String bed_file
@@ -20,7 +22,9 @@ workflow vardict {
 
     parameter_meta {
         tumor_bam: "tumor_bam file for analysis sample"
+        tumor_bai: "index for tumor bam file"
         normal_bam: "normal_bam file for analysis sample"
+        normal_bai: "index for normal bam file"
         tumor_sample_name:"Sample name for the tumor bam"
         normal_sample_name: "Sample name for the normal bam"
         bed_file: "BED files for specifying regions of interest"
@@ -54,7 +58,9 @@ workflow vardict {
         call runVardict { 
             input: 
                 tumor_bam = tumor_bam,
+                tumor_bai = tumor_bai,
                 normal_bam = normal_bam,
+                normal_bai = normal_bai,
                 tumor_sample_name = tumor_sample_name,
                 normal_sample_name = normal_sample_name,
                 bed_file = splitBedByChromosome.bed_files[i],
@@ -166,7 +172,9 @@ task splitBedByChromosome {
 task runVardict {
     input {
         File tumor_bam
+        File tumor_bai
         File normal_bam
+        File normal_bai
         String tumor_sample_name
         String normal_sample_name
         String refFasta
@@ -184,7 +192,9 @@ task runVardict {
     }
     parameter_meta {
         tumor_bam: "tumor_bam file for analysis sample"
+        tumor_bai: "index for tumor bam file"
         normal_bam: "normal_bam file for analysis sample"
+        normal_bai: "index for normal bam file"
         tumor_sample_name:"Sample name for the tumor bam"
         normal_sample_name: "Sample name for the normal bam"
         refFai: "Reference fasta fai index"

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -13,9 +13,33 @@
                 },
                 "type": "EXTERNAL"
             },
+            "vardict.tumor_bai": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/mutect2/input_data/PCSI0022P.sorted.filter.deduped.realigned.recal.bam.bai",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
             "vardict.normal_bam": {
                 "contents": {
                     "configuration": "/.mounts/labs/gsi/testdata/mutect2/input_data/PCSI0022R.val.bam",
+                    "externalIds": [
+                        {
+                            "id": "TEST",
+                            "provider": "TEST"
+                        }
+                    ]
+                },
+                "type": "EXTERNAL"
+            },
+            "vardict.normal_bai": {
+                "contents": {
+                    "configuration": "/.mounts/labs/gsi/testdata/mutect2/input_data/PCSI0022R.val.bam.bai",
                     "externalIds": [
                         {
                             "id": "TEST",


### PR DESCRIPTION
Added bam index for tumor and normal file explictly as input for the wdl, since vardict is actually using them. no changes otherwise, vardict will automatically found the indexes. 