### PR TITLE
Grd 951

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.0.0] - 2025-03-10
-### Added
-- [GRD-833](https://jira.oicr.on.ca/browse/GRD-833), first verion of the wdl along with README and vidarr files
-
+## [1.0.2] - 2025-06-10
+### Changed
+- [GRD-833](https://jira.oicr.on.ca/browse/GRD-833) Changed the order of input files to ensure 
+the correct order of data columns in vcf (NORMAL/TUMOR), satisfying the requirements of Neoantigen pipeline
 
 ## [1.0.1] - 2025-04-01
 ### Added
 - Added bam index as input of workflow
+
+## [1.0.0] - 2025-03-10
+### Added
+- [GRD-833](https://jira.oicr.on.ca/browse/GRD-833), first verion of the wdl along with README and vidarr files
+

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ VarDict is an ultra sensitive variant caller for both single and paired sample v
 ## Usage
 
 ### Cromwell
+
 ```
 java -jar cromwell.jar run vardict.wdl --inputs inputs.json
 ```
@@ -30,11 +31,6 @@ Parameter|Value|Description
 `normal_sample_name`|String|Sample name for the normal bam
 `bed_file`|String|BED files for specifying regions of interest
 `reference`|String|the reference genome for input sample
-
-
-#### Optional workflow parameters:
-Parameter|Value|Default|Description
----|---|---|---
 
 
 #### Optional task parameters:
@@ -60,7 +56,9 @@ Output | Type | Description | Labels
 `vardictVcf`|File|Merged vcf, unfiltered.|
 `vardictVcfIndex`|File|VCF index for variant calling from vardict|vidarr_label: vardcit_index
 
+
 ## Commands
+
 This section lists command(s) run by vardict workflow
 
 * Running vardict
@@ -102,7 +100,7 @@ This section lists command(s) run by vardict workflow
             -G ~{refFasta} \
             -f ~{AF_THR} \
             -N ~{tumor_sample_name} \
-            -b "~{tumor_bam}|~{normal_bam}" \
+            -b "~{normal_bam}|~{tumor_bam}" \
             -Q ~{MAP_QUAL} \
             --nosv \
             -P ~{READ_POSITION_FILTER} \
@@ -110,7 +108,7 @@ This section lists command(s) run by vardict workflow
              ~{bed_file} | \
             $RSTATS_ROOT/bin/Rscript $VARDICT_ROOT/bin/testsomatic.R | \
             $PERL_ROOT/bin/perl $VARDICT_ROOT/bin/var2vcf_paired.pl \
-            -N "~{tumor_sample_name}|~{normal_sample_name}" \
+            -N "~{normal_sample_name}|~{tumor_sample_name}" \
             -f ~{AF_THR} | bgzip  > vardict.vcf.gz
 
             # the vardict generated vcf header missing contig name, need extract contig lines from refFai
@@ -131,7 +129,6 @@ This section lists command(s) run by vardict workflow
     O=~{tumor_sample_name}.vardict.vcf.gz \
     SEQUENCE_DICTIONARY=~{refDict}
 ```
-
 ## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ VarDict is an ultra sensitive variant caller for both single and paired sample v
 ## Dependencies
 
 * [vardict 1.8.3](https://github.com/pachterlab/vardict)
+* [tabix 0.2.6](http://www.htslib.org)
 * [java](https://www.java.com/en/)
 
 
@@ -58,78 +59,92 @@ Output | Type | Description | Labels
 
 
 ## Commands
-
-This section lists command(s) run by vardict workflow
-
-* Running vardict
-
-```
-        set -euo pipefail
-        
-        mkdir split_beds
-        CHROMS=($(seq 1 22) X Y)
-        
-        for chr in "${CHROMS[@]}"; do
-            grep -E "^(chr)?${chr}[[:space:]]" ~{bed_file} > split_beds/chr${chr}.bed || true
-            if [ -s split_beds/chr${chr}.bed ]; then
-                echo "split_beds/chr${chr}.bed" >> split_beds.list
-                # Calculate range size for this bed
-                range_size=$(awk '{sum += ($3 - $2)} END {print sum}' split_beds/chr${chr}.bed)
-                echo "${range_size}" >> range_sizes.txt
-            fi
-        done
-        min_coff=0.8
-        p=0.8
-        max_size=$(sort -n range_sizes.txt | tail -n1)
-
-        awk -v max="$max_size" -v min_coff="$min_coff" -v p="$p" '
-        {
-            size = $1
-            ratio = size / max
-            coefficient = min_coff + (1 - min_coff) * (ratio ^ p)
-            printf "%.2f\n", coefficient
-        }' range_sizes.txt > memory_coefficients.txt
-```
-```
-        set -euo pipefail
-        cp ~{refFai} .
-        
-        export JAVA_OPTS="-Xmx$(echo "scale=0; ~{allocatedMemory} * 0.8 / 1" | bc)G"
-        $VARDICT_ROOT/bin/VarDict \
-            -th ~{numThreads} \
-            -G ~{refFasta} \
-            -f ~{AF_THR} \
-            -N ~{tumor_sample_name} \
-            -b "~{normal_bam}|~{tumor_bam}" \
-            -Q ~{MAP_QUAL} \
-            --nosv \
-            -P ~{READ_POSITION_FILTER} \
-            -c 1 -S 2 -E 3 -g 4 \
-             ~{bed_file} | \
-            $RSTATS_ROOT/bin/Rscript $VARDICT_ROOT/bin/testsomatic.R | \
-            $PERL_ROOT/bin/perl $VARDICT_ROOT/bin/var2vcf_paired.pl \
-            -N "~{normal_sample_name}|~{tumor_sample_name}" \
-            -f ~{AF_THR} | bgzip  > vardict.vcf.gz
-
-            # the vardict generated vcf header missing contig name, need extract contig lines from refFai
-            bcftools view -h vardict.vcf.gz > header.txt     
-            while read -r name length rest; do 
-                echo "##contig=<ID=$name,length=$length>" 
-            done < ~{refFai} >> header.txt
-
-            bcftools reheader -h header.txt -o ~{tumor_sample_name}_~{normal_sample_name}.vardict.vcf.gz vardict.vcf.gz
-            tabix -p vcf ~{tumor_sample_name}_~{normal_sample_name}.vardict.vcf.gz
-            
-```
-```
-    set -euo pipefail
-
-    java "-Xmx~{memory-3}g" -jar $PICARD_ROOT/picard.jar MergeVcfs \
-    ~{sep=" " prefix("I=", vcfs)} \
-    O=~{tumor_sample_name}.vardict.vcf.gz \
-    SEQUENCE_DICTIONARY=~{refDict}
-```
-## Support
+ This section lists command(s) run by vardict workflow
+ 
+ * Running vardict
+ 
+ 
+ ### Calculate memory allocation coefficients
+ 
+ Depending on the size, each chromosome-specific shard gets a specific amount of RAM
+ 
+ ```
+         set -euo pipefail
+         
+         mkdir split_beds
+         CHROMS=($(seq 1 22) X Y)
+         
+         for chr in "${CHROMS[@]}"; do
+             grep -E "^(chr)?${chr}[[:space:]]" ~{bed_file} > split_beds/chr${chr}.bed || true
+             if [ -s split_beds/chr${chr}.bed ]; then
+                 echo "split_beds/chr${chr}.bed" >> split_beds.list
+                 # Calculate range size for this bed
+                 range_size=$(awk '{sum += ($3 - $2)} END {print sum}' split_beds/chr${chr}.bed)
+                 echo "${range_size}" >> range_sizes.txt
+             fi
+         done
+         min_coff=0.8
+         p=0.8
+         max_size=$(sort -n range_sizes.txt | tail -n1)
+ 
+         awk -v max="$max_size" -v min_coff="$min_coff" -v p="$p" '
+         {
+             size = $1
+             ratio = size / max
+             coefficient = min_coff + (1 - min_coff) * (ratio ^ p)
+             printf "%.2f\n", coefficient
+         }' range_sizes.txt > memory_coefficients.txt
+ ```
+ 
+ ### Run vardict
+ 
+ This is a task which runs in a scatter, one shard per chromosome
+ 
+ ```
+         set -euo pipefail
+         cp ~{refFai} .
+         
+         export JAVA_OPTS="-Xmx$(echo "scale=0; ~{allocatedMemory} * 0.8 / 1" | bc)G"
+         $VARDICT_ROOT/bin/VarDict \
+             -th ~{numThreads} \
+             -G ~{refFasta} \
+             -f ~{AF_THR} \
+             -N ~{tumor_sample_name} \
+             -b "~{normal_bam}|~{tumor_bam}" \
+             -Q ~{MAP_QUAL} \
+             --nosv \
+             -P ~{READ_POSITION_FILTER} \
+             -c 1 -S 2 -E 3 -g 4 \
+              ~{bed_file} | \
+             $RSTATS_ROOT/bin/Rscript $VARDICT_ROOT/bin/testsomatic.R | \
+             $PERL_ROOT/bin/perl $VARDICT_ROOT/bin/var2vcf_paired.pl \
+             -N "~{normal_sample_name}|~{tumor_sample_name}" \
+             -f ~{AF_THR} | bgzip  > vardict.vcf.gz
+ 
+             # the vardict generated vcf header missing contig name, need extract contig lines from refFai
+             bcftools view -h vardict.vcf.gz > header.txt     
+             while read -r name length rest; do 
+                 echo "##contig=<ID=$name,length=$length>" 
+             done < ~{refFai} >> header.txt
+ 
+             bcftools reheader -h header.txt -o ~{tumor_sample_name}_~{normal_sample_name}.vardict.vcf.gz vardict.vcf.gz
+             tabix -p vcf ~{tumor_sample_name}_~{normal_sample_name}.vardict.vcf.gz
+             
+ ```
+ ### Merge chromosome-specific vcf files
+ 
+ Using vcftools we merge chromosome-specific chunks into one vcf. Additional post-processing required
+ to remove extra header lines from chunk-specific vcf files
+ 
+ ```
+     set -euo pipefail
+     $VCFTOOLS_ROOT/bin/vcf-concat ~{sep=" " vcfs} > temp.vcf
+     grep ^# test.vcf | perl -ne 'BEGIN{$end=0}{print if !$end;if(/CHROM/){$end = 1;}}' > ~{tumor_sample_name}.vardict.vcf
+     grep -v ^# temp.vcf >> ~{tumor_sample_name}.vardict.vcf
+     bgzip ~{tumor_sample_name}.vardict.vcf
+     tabix -p vcf ~{tumor_sample_name}.vardict.vcf.gz
+ ```
+ ## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .
 

--- a/commands.txt
+++ b/commands.txt
@@ -40,7 +40,7 @@ This section lists command(s) run by vardict workflow
             -G ~{refFasta} \
             -f ~{AF_THR} \
             -N ~{tumor_sample_name} \
-            -b "~{tumor_bam}|~{normal_bam}" \
+            -b "~{normal_bam}|~{tumor_bam}" \
             -Q ~{MAP_QUAL} \
             --nosv \
             -P ~{READ_POSITION_FILTER} \
@@ -48,7 +48,7 @@ This section lists command(s) run by vardict workflow
              ~{bed_file} | \
             $RSTATS_ROOT/bin/Rscript $VARDICT_ROOT/bin/testsomatic.R | \
             $PERL_ROOT/bin/perl $VARDICT_ROOT/bin/var2vcf_paired.pl \
-            -N "~{tumor_sample_name}|~{normal_sample_name}" \
+            -N "~{normal_sample_name}|~{tumor_sample_name}" \
             -f ~{AF_THR} | bgzip  > vardict.vcf.gz
 
             # the vardict generated vcf header missing contig name, need extract contig lines from refFai

--- a/commands.txt
+++ b/commands.txt
@@ -3,6 +3,11 @@ This section lists command(s) run by vardict workflow
 
 * Running vardict
 
+
+### Calculate memory allocation coefficients
+
+Depending on the size, each chromosome-specific shard gets a specific amount of RAM
+
 ```
         set -euo pipefail
         
@@ -30,6 +35,11 @@ This section lists command(s) run by vardict workflow
             printf "%.2f\n", coefficient
         }' range_sizes.txt > memory_coefficients.txt
 ```
+
+### Run vardict
+
+This is a task which runs in a scatter, one shard per chromosome
+
 ```
         set -euo pipefail
         cp ~{refFai} .
@@ -61,11 +71,16 @@ This section lists command(s) run by vardict workflow
             tabix -p vcf ~{tumor_sample_name}_~{normal_sample_name}.vardict.vcf.gz
             
 ```
+### Merge chromosome-specific vcf files
+
+Using vcftools we merge chromosome-specific chunks into one vcf. Additional post-processing required
+to remove extra header lines from chunk-specific vcf files
+
 ```
     set -euo pipefail
-
-    java "-Xmx~{memory-3}g" -jar $PICARD_ROOT/picard.jar MergeVcfs \
-    ~{sep=" " prefix("I=", vcfs)} \
-    O=~{tumor_sample_name}.vardict.vcf.gz \
-    SEQUENCE_DICTIONARY=~{refDict}
+    $VCFTOOLS_ROOT/bin/vcf-concat ~{sep=" " vcfs} > temp.vcf
+    grep ^# test.vcf | perl -ne 'BEGIN{$end=0}{print if !$end;if(/CHROM/){$end = 1;}}' > ~{tumor_sample_name}.vardict.vcf
+    grep -v ^# temp.vcf >> ~{tumor_sample_name}.vardict.vcf
+    bgzip ~{tumor_sample_name}.vardict.vcf
+    tabix -p vcf ~{tumor_sample_name}.vardict.vcf.gz
 ```

--- a/vardict.wdl
+++ b/vardict.wdl
@@ -222,7 +222,7 @@ task runVardict {
             -G ~{refFasta} \
             -f ~{AF_THR} \
             -N ~{tumor_sample_name} \
-            -b "~{tumor_bam}|~{normal_bam}" \
+            -b "~{normal_bam}|~{tumor_bam}" \
             -Q ~{MAP_QUAL} \
             --nosv \
             -P ~{READ_POSITION_FILTER} \
@@ -230,7 +230,7 @@ task runVardict {
              ~{bed_file} | \
             $RSTATS_ROOT/bin/Rscript $VARDICT_ROOT/bin/testsomatic.R | \
             $PERL_ROOT/bin/perl $VARDICT_ROOT/bin/var2vcf_paired.pl \
-            -N "~{tumor_sample_name}|~{normal_sample_name}" \
+            -N "~{normal_sample_name}|~{tumor_sample_name}" \
             -f ~{AF_THR} | bgzip  > vardict.vcf.gz
 
             # the vardict generated vcf header missing contig name, need extract contig lines from refFai
@@ -304,3 +304,4 @@ task mergeVcfs {
     File mergedVcfIdx = "~{tumor_sample_name}.vardict.vcf.gz.tbi"
   }
 }
+

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -103,7 +103,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/vardict/output_expectation/1.0.0/vardict_test.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/vardict/output_expectation/1.0.2/vardict_test.metrics",
                 "type": "script"
             }
         ]


### PR DESCRIPTION
As we noticed some undesired behaviour of this workflow, some changes were introduced and tested:

- order of samples changed to normal | tumor in vardict task to ensure compliance with other parts of Neoantigen pipeline
- merging of vcf files is now done with vcf-tools as it looks like Picard (GATK) silently swaps NORMAL and TUMOR columns in vcf so that we have alphabetically sorted samples. We may discuss this at some point as it seems to be a recurring theme. However, the changes in this PR enable us to manually control the order of sample is vcf so there are no surprises